### PR TITLE
Remove toLowerCase for months and days in statistics

### DIFF
--- a/app/src/main/java/com/minar/birday/utilities/StatsGenerator.kt
+++ b/app/src/main/java/com/minar/birday/utilities/StatsGenerator.kt
@@ -114,7 +114,7 @@ class StatsGenerator(eventList: List<EventResult>, context: Context?) {
         }
         commonMonth = evaluateResult(months)
         if (commonMonth.isBlank()) return commonMonth
-        return applicationContext?.getString(R.string.most_common_month) + " " + commonMonth.toLowerCase(Locale.ROOT)
+        return applicationContext?.getString(R.string.most_common_month) + " " + commonMonth
     }
 
     // The most common age range (decade). When there's no common range, return a blank string
@@ -190,7 +190,7 @@ class StatsGenerator(eventList: List<EventResult>, context: Context?) {
     private fun dayOfWeek(person: EventResult): String {
         return if (!person.yearMatter!!) ""
         else person.name + " " + applicationContext?.getString(R.string.random_day_of_week) + " " +
-                person.originalDate.dayOfWeek.getDisplayName(TextStyle.FULL, Locale.getDefault()).toLowerCase(Locale.ROOT)
+                person.originalDate.dayOfWeek.getDisplayName(TextStyle.FULL, Locale.getDefault())
     }
 
     // The most common day of the week of birth. When there's no common day of the week, return a blank string
@@ -206,7 +206,7 @@ class StatsGenerator(eventList: List<EventResult>, context: Context?) {
         }
         commonWeekDay = evaluateResult(weekDays)
         if (commonWeekDay.isBlank()) return commonWeekDay
-        return applicationContext?.getString(R.string.most_common_day_of_week) + " " + commonWeekDay.toLowerCase(Locale.ROOT)
+        return applicationContext?.getString(R.string.most_common_day_of_week) + " " + commonWeekDay
     }
 
     // Get the number of persons born in a leap year. Even 0 is an acceptable result

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -29,8 +29,8 @@
     <string name="customization">Anpassung</string>
     <string name="app_behavior">App-Verhalten</string>
     <string name="additional_notification_name">Zusätzliche Benachrichtigung</string>
-    <string name="additional_notification_description">Sende eine zusätzliche Benachrichtigung %s Tage vor jedem Geburtstag</string>
-    <string name="no_additional_notification">Nie</string>
+    <string name="additional_notification_description">Sende eine zusätzliche Benachrichtigung  vor jedem Geburtstag: %s</string>
+    <string name="no_additional_notification">Keine</string>
     <string name="one_day_before">Einen Tag vorher</string>
     <string name="two_days_before">Zwei Tag vorher</string>
     <string name="three_days_before">Drei Tage vorher</string>
@@ -43,7 +43,7 @@
     <string name="vibration_description_off">Keine Vibration bei Tastendruck</string>
     <string name="date_format_name">Datumsformat</string>
     <string name="notification_hour_name">Uhrzeit der Benachrichtigung</string>
-    <string name="notification_hour_description">%s \n\nBitte beachte, dass die Benachrichtigung möglicherweise nicht funktioniert, wenn die App in einigen Huawei-, Xiaomi- und OnePlus-Geräten vom System beendet wird. Weitere informationnen findest du unter dontkillmyapp.com</string>
+    <string name="notification_hour_description">%s \n\nBitte beachte, dass die Benachrichtigung möglicherweise nicht funktioniert, wenn die App auf einigen Huawei-, Xiaomi- und OnePlus-Geräten vom System beendet wird. Weitere Informationen findest du unter dontkillmyapp.com</string>
     <string name="accent_description">Ändern der Standard-Akzentfarbe</string>
     <string name="accent_name">Akzentfarbe</string>
     <string name="theme_description">Verwende ein dunkles, helles oder automatisches App-Theme</string>
@@ -84,12 +84,12 @@
     <string name="birday_export_success">Export abgeschlossen!</string>
     <string name="birday_export_failure">Export fehlgeschlagen. Ups!</string>
     <string name="birday_export_nothing_found">Nichts zum exportieren!</string>
-    <string name="surname_first">Nachname für zuerst</string>
-    <string name="surname_first_description_on">Zeigen Sie den Nachnamen vor dem Namen</string>
-    <string name="surname_first_description_off">Zeigen Sie den Namen vor dem Nachnamen</string>
+    <string name="surname_first">Nachname zuerst</string>
+    <string name="surname_first_description_on">Zeige den Nachnamen vor dem Vornamen</string>
+    <string name="surname_first_description_off">Zeige den Vornamen vor dem Nachnamen</string>
 
     <!-- Developer -->
-    <string name="dev_description">Ich bin ein netter Mensch und ich mag schöne Dinge, wie Animationen, Icons, Sportwagen und 3D-Druck. Ich arbeite als Designer und Computeringenieur.</string>
+    <string name="dev_description">Ich bin ein netter Mensch und ich mag schöne Dinge wie Animationen, Icons, Sportwagen und 3D-Druck. Ich arbeite als Designer und Computeringenieur.</string>
     <string name="easter_egg">Schönes logo, hm? ;D</string>
 
     <!-- New event -->
@@ -97,7 +97,7 @@
     <string name="new_event_description">Gib eine neue Person ein, die dir wichtig ist, und Birday wird dir helfen, dich an ihren Geburtstag zu erinnern!</string>
     <string name="insert_event">Geburtstag eingeben</string>
     <string name="cancel">Abbrechen</string>
-    <string name="insert_name_hint">Namen eingeben</string>
+    <string name="insert_name_hint">Vornamen eingeben</string>
     <string name="insert_surname_hint">Nachnamen eingeben</string>
     <string name="insert_date_hint">Wähle ein Datum</string>
     <string name="invalid_value_name">Ungültiger Name. Zahlen und Symbole sind nicht erlaubt!</string>
@@ -107,7 +107,7 @@
     <string name="event_actions_description">hier kannst du dieses Ereignis löschen oder einfach bearbeiten!</string>
     <string name="edit_event">Ereignis bearbeiten</string>
     <string name="delete_event">Ereignis löschen</string>
-    <string name="update_event">Ereignis updaten</string>
+    <string name="update_event">Ereignis aktualisieren</string>
     <string name="share_event">Ereignis teilen</string>
 
     <!-- Event details -->
@@ -118,12 +118,12 @@
     <string name="chinese_zodiac_sign">Chinesisches Zeichen:</string>
 
     <!-- Quick apps -->
-    <string name="event_apps">Quick apps</string>
-    <string name="event_apps_description">Apps um schnell alles Gute zu wünschen!</string>
+    <string name="event_apps">Schnell-Apps</string>
+    <string name="event_apps_description">Apps, um schnell alles Gute zu wünschen!</string>
     <string name="whatsapp">Whatsapp</string>
     <string name="telegram">Telegram</string>
     <string name="textMessage">Textnachricht</string>
-    <string name="dialer">Dialer</string>
+    <string name="dialer">Telefon</string>
     <string name="wishes">Alles Gute zum Geburtstag!</string>
     <string name="no_default_dialer">Keine Standard-Dialer-App gefunden</string>
     <string name="no_default_sms">Keine Standard SMS App gefunden!</string>
@@ -133,7 +133,7 @@
     <string name="age_average">Das Durchschnittsalter ist</string>
     <string name="oldest_person">Die älteste Person ist</string>
     <string name="youngest_person">Die jüngste Person ist</string>
-    <string name="most_common_month">Der häufigste Geburtsmonat ists</string>
+    <string name="most_common_month">Der häufigste Geburtsmonat ist</string>
     <string name="most_common_decade">Das häufigste Geburtsjahrzehnt ist</string>
     <string name="most_common_age_range">Die häufigste Altersgruppe ist</string>
     <string name="special_ages">Ein wichtiger bevorstehender Geburtstag ist</string>
@@ -161,7 +161,7 @@
     <string name="zodiac_pisces">Fische</string>
     <string name="zodiac_aries">Widder</string>
     <string name="zodiac_taurus">Stier</string>
-    <string name="zodiac_gemini">gemini</string>
+    <string name="zodiac_gemini">Zwillinge</string>
     <string name="zodiac_cancer">Zwillinge</string>
     <string name="zodiac_leo">Löwe</string>
     <string name="zodiac_virgo">Jungfrau</string>
@@ -193,11 +193,11 @@
 
     <!-- Introduction slides -->
     <string name="slide_one_title">Willkommen zu Birday!</string>
-    <string name="slide_one_description">Birday ist eine einfache und leichte App zum Verwalten wichtiger Ereignisse! Mit ihr kannst du Geburtstage von Menschen die du liebst zuverlässig und schnell merken und speichern.</string>
+    <string name="slide_one_description">Birday ist eine einfache und leichte App zum Verwalten wichtiger Ereignisse! Mit ihr kannst du Geburtstage von Menschen, die du liebst, zuverlässig und schnell merken und speichern.</string>
     <string name="slide_two_title">Kostenlos, einfach, individualisierbar</string>
-    <string name="slide_two_description">Birday ist kostenlos, werbefrei und open source. Es bietet eine Reihe von Statistiken über deine Geburtstage, ein Favoritensystem und eine anpassbare Oberfläche. Und garantierter Support und Updates!</string>
+    <string name="slide_two_description">Birday ist kostenlos, werbefrei und quelloffen. Es bietet eine Reihe von Statistiken über deine Geburtstage, ein Favoritensystem und eine anpassbare Oberfläche. Und garantierten Support und Updates!</string>
     <string name="slide_three_title">Import aus Google-Kontakten</string>
-    <string name="slide_three_description">Es ist auch möglich, die bereits gespeicherten Geburtstage aus deinen Google-Kontakten zu importieren. Birday kann das für dich erledigen, gebe einfache die Kontakterlaubnis. Viel Spaß!</string>
+    <string name="slide_three_description">Es ist auch möglich, die bereits gespeicherten Geburtstage aus deinen Google-Kontakten zu importieren. Birday kann das für dich erledigen, gib der App einfach die Kontakterlaubnis. Viel Spaß!</string>
 
     <!-- Widget -->
     <string name="appwidget_upcoming">Bevorstehende Geburtstage</string>
@@ -207,6 +207,6 @@
     <string name="search_event">Suchen…</string>
     <string name="search_no_result_title">Keine Ergebnisse gefunden</string>
     <string name="search_no_result_description">Dein Suchbegriff stimmt mit keinem Ereignis in der Birday-Datenbank überein!</string>
-    <string name="consider_year">Betrachten Sie das Jahr</string>
+    <string name="consider_year">Inklusive Jahr</string>
 
 </resources>


### PR DESCRIPTION
## Remove toLowerCase for months and days in statistics

This pull requests **remove lowercasing from week days & months**.
It is part 2 of fixing German translations. I made it seperate since I don't quite know why you introduced lowercasing.

Lowercasing torpedoed German translations, because months and days need to be uppercase there. (e.g. `Montag` for Monday)

This capitalisation applies to English as well:
https://en.wikipedia.org/wiki/Capitalization_in_English#When_to_capitalize
> days and months: "Monday", "January", but not seasons such as "autumn".

And since the Java Calendar `getDisplayName(Locale)` already considers capitalisation for different languages, this change shouldn't affect other languages that don't capitalise.

I'm not sure why you would even introduce lowercasing in the first place. ¯\\\_(ツ)\_/¯

Hope it helps, you likely didn't know about the problem.