### PR TITLE
Fixed pisces translation

### DIFF
--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -182,7 +182,7 @@
     <string name="zodiac_sagittarius">strijelac</string>
     <string name="zodiac_capricorn">jarac</string>
     <string name="zodiac_aquarius">vodenjak</string>
-    <string name="zodiac_pisces">riba</string>
+    <string name="zodiac_pisces">ribe</string>
     <string name="zodiac_aries">ovan</string>
     <string name="zodiac_taurus">bik</string>
     <string name="zodiac_gemini">blizanci</string>


### PR DESCRIPTION
Pisces refers to two fish, apparently. Welp, you learn something new every day.