### PR TITLE
Add basic GH Action

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,10 @@
+name: Build
+on: [pull_request, push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@v2
+      - name: Build the app
+        run: ./gradlew build


### PR DESCRIPTION
I ~copied~ created the most basic workflow ~I could find on the internet~ to android apps. However, the build is failing on `master`. Is that an expected behaviour? That's pretty useful start point to be able to check if a PR is going to break the build.