### PR TITLE
Fix translation

### DIFF
--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -109,7 +109,7 @@
     <string name="notification_only_favorites_description_off">Prikaži obavijest za svaki uneseni događaj</string>
     <string name="troubleshoot">Rješavanje problema</string>
     <string name="battery_optimization_title">Onemogućite optimizaciju baterije</string>
-    <string name="battery_optimization_description">Otvorite postavke da biste onemogućili bilo kakvu optimizaciju za Birday</string>
+    <string name="battery_optimization_description">Prečac do postavki za onemogućivanje uštede baterije za Birday. Korisno ako obavijesti ne funkcioniraju</string>
     <string name="notification_sound_title">Zvuk obavijesti</string>
     <string name="notification_sound_description">Prečac do postavki zvuka obavijesti, ako vam se ne sviđa zadani zvuk ptica</string>
 


### PR DESCRIPTION
Before you merge this, where are the <plurals name="event"> strings used? Also, I noticed that the English strings.xml has markedly more lines than others. Are some of the strings missing?