### PR TITLE
Feature: Haptic Feedback

### DIFF
--- a/app/src/main/java/com/minar/birday/activities/MainActivity.kt
+++ b/app/src/main/java/com/minar/birday/activities/MainActivity.kt
@@ -366,6 +366,7 @@ class MainActivity : AppCompatActivity() {
     }
 
     // Vibrate using a standard vibration pattern
+    // or use system Haptic feedback if vibration is disabled
     fun vibrate() {
         // Deprecated for no reason
         val vib = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
@@ -376,12 +377,15 @@ class MainActivity : AppCompatActivity() {
             @Suppress("DEPRECATION")
             getSystemService(VIBRATOR_SERVICE) as Vibrator
         }
-        if (sharedPrefs.getBoolean(
-                "vibration",
-                true
-            )
-        ) // Vibrate if the vibration in options is set to on
+
+        if (sharedPrefs.getBoolean("vibration", true)) {
+            // Vibrate if the vibration in options is set to on
             vib.vibrate(VibrationEffect.createOneShot(30, VibrationEffect.DEFAULT_AMPLITUDE))
+        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            // Use system Haptic feedback
+            if (vib.areEffectsSupported(VibrationEffect.EFFECT_CLICK)[0] == Vibrator.VIBRATION_EFFECT_SUPPORT_YES)
+                vib.vibrate(VibrationEffect.createPredefined(VibrationEffect.EFFECT_CLICK))
+        }
     }
 
     // Show a snackbar containing a given text and an optional action, with a 5 seconds duration

--- a/app/src/main/java/com/minar/birday/activities/MainActivity.kt
+++ b/app/src/main/java/com/minar/birday/activities/MainActivity.kt
@@ -378,7 +378,7 @@ class MainActivity : AppCompatActivity() {
             getSystemService(VIBRATOR_SERVICE) as Vibrator
         }
 
-        if (sharedPrefs.getBoolean("vibration", true)) {
+        if (sharedPrefs.getBoolean("vibration", false)) {
             // Vibrate if the vibration in options is set to on
             vib.vibrate(VibrationEffect.createOneShot(30, VibrationEffect.DEFAULT_AMPLITUDE))
         } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -90,7 +90,7 @@
             app:iconSpaceReserved="false" />
 
         <SwitchPreferenceCompat
-            android:defaultValue="true"
+            android:defaultValue="false"
             android:key="vibration"
             android:summaryOff="@string/vibration_description_off"
             android:summaryOn="@string/vibration_description_on"


### PR DESCRIPTION
_It's one of the 4 pull requests sent in parallel. They are all already merged in https://github.com/simonesestito/birday/tree/merge-all_

Let's be honest: using the custom vibrator is actually bad for the user experience.
With this feature, the vibrator is turned off by default, and it uses the real Haptic Feedback, following the real phone user experience.
Incredibly better for those users with a good haptic feedback!